### PR TITLE
feat: add ECU module auto-discovery via UDS TesterPresent probe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
 		<dependency>
 			<groupId>io.github.tzebrowski</groupId>
 			<artifactId>obd-metrics-test</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.6.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.tzebrowski</groupId>
 	<artifactId>obd-metrics</artifactId>
-	<version>11.25.0-SNAPSHOT</version>
+	<version>11.26.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>OBD Metrics</name>
 	<description>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
 		<dependency>
 			<groupId>io.github.tzebrowski</groupId>
 			<artifactId>obd-metrics-test</artifactId>
-			<version>1.6.0-SNAPSHOT</version>
+			<version>1.5.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/src/main/java/org/obd/metrics/api/DefaultWorkflow.java
+++ b/src/main/java/org/obd/metrics/api/DefaultWorkflow.java
@@ -125,6 +125,19 @@ final class DefaultWorkflow implements Workflow {
 	}
 
 	@Override
+	public WorkflowExecutionStatus discoverModule(@NonNull String header) {
+		log.info("[Discovery] Probing header: {}", header);
+
+		if (isRunning() && activeContext != null) {
+			activeContext.discoverModule(header);
+			return WorkflowExecutionStatus.DISCOVERY_QUEUED;
+		} else {
+			log.warn("[Discovery] No workflow is running");
+			return WorkflowExecutionStatus.NOT_RUNNING;
+		}
+	}
+
+	@Override
 	public WorkflowExecutionStatus updateQuery(@NonNull Query query, @NonNull Init init, @NonNull Adjustments adjustments) {
 		long ts = System.currentTimeMillis();
 		log.info("[Update] Updating running workflow with new query");

--- a/src/main/java/org/obd/metrics/api/ExecutionContext.java
+++ b/src/main/java/org/obd/metrics/api/ExecutionContext.java
@@ -29,6 +29,7 @@ import org.obd.metrics.api.model.Query;
 import org.obd.metrics.buffer.CommandsBuffer;
 import org.obd.metrics.buffer.decoder.ConnectorResponseBuffer;
 import org.obd.metrics.command.ATCommand;
+import org.obd.metrics.command.discovery.ModuleDiscoveryCommand;
 import org.obd.metrics.command.obd.ObdCommand;
 import org.obd.metrics.command.process.DiagnosticTroubleCodeScheduleCommand;
 import org.obd.metrics.command.process.QuitCommand;
@@ -106,6 +107,14 @@ final class ExecutionContext {
 
 		log.info("[DTC] Adding DTC schedule command");
 		commandsBuffer.addLast(new DiagnosticTroubleCodeScheduleCommand(actions));
+		commandProducer.resume();
+	}
+
+	void discoverModule(String header) {
+		log.info("[Discovery] Probing header {}", header);
+		commandProducer.pause();
+		commandsBuffer.addLast(new ATCommand("SH" + header));
+		commandsBuffer.addLast(new ModuleDiscoveryCommand(header));
 		commandProducer.resume();
 	}
 

--- a/src/main/java/org/obd/metrics/api/ExecutionContext.java
+++ b/src/main/java/org/obd/metrics/api/ExecutionContext.java
@@ -113,6 +113,7 @@ final class ExecutionContext {
 	void discoverModule(String header) {
 		log.info("[Discovery] Probing header {}", header);
 		commandProducer.pause();
+		commandsBuffer.clear();
 		commandsBuffer.addLast(new ATCommand("SH" + header));
 		commandsBuffer.addLast(new ModuleDiscoveryCommand(header));
 		commandProducer.resume();

--- a/src/main/java/org/obd/metrics/api/ExecutionContextFactory.java
+++ b/src/main/java/org/obd/metrics/api/ExecutionContextFactory.java
@@ -92,6 +92,7 @@ final class ExecutionContextFactory {
         @SuppressWarnings("unchecked")
 		final EventsPublishlisher<Reply<?>> publisher = EventsPublishlisher.builder()
                 .observer(new RoutinesResponseObserver<>(subscription))
+                .observer(new ModuleDiscoveryResponseObserver<>(subscription))
                 .observer(externalEventsObserver)
                 .observer((ReplyObserver<Reply<?>>) alerts)
                 .observer((ReplyObserver<Reply<?>>) diagnostics).build();

--- a/src/main/java/org/obd/metrics/api/ModuleDiscoveryResponseObserver.java
+++ b/src/main/java/org/obd/metrics/api/ModuleDiscoveryResponseObserver.java
@@ -1,0 +1,65 @@
+ /**
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.metrics.api;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.obd.metrics.api.model.Lifecycle.Subscription;
+import org.obd.metrics.api.model.ModuleDiscoveryStatus;
+import org.obd.metrics.api.model.Reply;
+import org.obd.metrics.api.model.ReplyObserver;
+import org.obd.metrics.command.discovery.ModuleDiscoveryCommand;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+final class ModuleDiscoveryResponseObserver<T> extends ReplyObserver<Reply<?>> {
+	private static final String SUCCESS_CODE = "7E00";
+
+	private final Subscription subscription;
+
+	@Override
+	public void onNext(Reply<?> reply) {
+		try {
+			final ModuleDiscoveryCommand command = (ModuleDiscoveryCommand) reply.getCommand();
+
+			final String response = reply.getRaw().getMessage();
+			log.info("Received module discovery response for header={}: {}", command.getHeader(), response);
+
+			ModuleDiscoveryStatus status = ModuleDiscoveryStatus.ERROR;
+			if (response.startsWith(SUCCESS_CODE)) {
+				status = ModuleDiscoveryStatus.FOUND;
+			} else if (reply.getRaw().isEmpty()) {
+				status = ModuleDiscoveryStatus.NOT_FOUND;
+			}
+
+			log.info("Module discovery header={} status={}", command.getHeader(), status);
+			subscription.onModuleDiscovered(command.getHeader(), status);
+
+		} catch (Throwable e) {
+			log.error("Failed to process module discovery response", e);
+		}
+	}
+
+	@Override
+	public List<Class<?>> subscribeFor() {
+		return Arrays.asList(ModuleDiscoveryCommand.class);
+	}
+}

--- a/src/main/java/org/obd/metrics/api/Workflow.java
+++ b/src/main/java/org/obd/metrics/api/Workflow.java
@@ -152,7 +152,16 @@ public interface Workflow {
 	 * @param init init settings of the Adapter
 	 */
 	WorkflowExecutionStatus executeRoutine(@NonNull Long id, @NonNull Init init);
-	
+
+	/**
+	 * Probes a single CAN header for a live module, for already running
+	 * workflow, using a UDS TesterPresent request. The result is delivered
+	 * asynchronously via {@link Lifecycle#onModuleDiscovered(String, org.obd.metrics.api.model.ModuleDiscoveryStatus)}.
+	 *
+	 * @param header the CAN header to probe, eg. "DA10F1"
+	 */
+	WorkflowExecutionStatus discoverModule(@NonNull String header);
+
 	/**
 	 * Updates query for already running workflow
 	 * 

--- a/src/main/java/org/obd/metrics/api/model/Lifecycle.java
+++ b/src/main/java/org/obd/metrics/api/model/Lifecycle.java
@@ -94,6 +94,18 @@ public interface Lifecycle {
 		}
 
 		@Override
+		public void onModuleDiscovered(String header, ModuleDiscoveryStatus status) {
+			log.debug("Triggering event onModuleDiscovered");
+			items.forEach(p -> {
+				try {
+					p.onModuleDiscovered(header, status);
+				} catch (Exception e) {
+					log.warn("Failed while executing onModuleDiscovered", e);
+				}
+			});
+		}
+
+		@Override
 		public void onError(String message, Throwable e) {
 			log.debug("Triggering event onError");
 			items.forEach(p -> {
@@ -143,6 +155,9 @@ public interface Lifecycle {
 	}
 
 	default void onRoutineCompleted(RoutineCommand routineCommand, RoutineExecutionStatus status) {
+	}
+
+	default void onModuleDiscovered(String header, ModuleDiscoveryStatus status) {
 	}
 
 	default void onStopped() {

--- a/src/main/java/org/obd/metrics/api/model/ModuleDiscoveryStatus.java
+++ b/src/main/java/org/obd/metrics/api/model/ModuleDiscoveryStatus.java
@@ -14,8 +14,8 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.obd.metrics.api;
+package org.obd.metrics.api.model;
 
-public enum WorkflowExecutionStatus {
-	STARTED, REJECTED, UPDATED, NOT_RUNNING, RUNNING, ROUTINE_QUEUED, DTC_QUEUED, DISCOVERY_QUEUED
+public enum ModuleDiscoveryStatus {
+	FOUND, NOT_FOUND, ERROR
 }

--- a/src/main/java/org/obd/metrics/command/discovery/ModuleDiscoveryCommand.java
+++ b/src/main/java/org/obd/metrics/command/discovery/ModuleDiscoveryCommand.java
@@ -14,8 +14,27 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.obd.metrics.api;
+package org.obd.metrics.command.discovery;
 
-public enum WorkflowExecutionStatus {
-	STARTED, REJECTED, UPDATED, NOT_RUNNING, RUNNING, ROUTINE_QUEUED, DTC_QUEUED, DISCOVERY_QUEUED
+import org.obd.metrics.command.Command;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * UDS TesterPresent (3E 00) probe used to check whether a module answers at
+ * a given CAN header, for ECU auto-discovery. Built directly from the
+ * header, not from a {@link org.obd.metrics.pid.PidDefinition} - discovery
+ * targets are ad-hoc candidate headers, not registry-managed PIDs.
+ */
+@EqualsAndHashCode(of = { "header" }, callSuper = false)
+public class ModuleDiscoveryCommand extends Command {
+
+	@Getter
+	private final String header;
+
+	public ModuleDiscoveryCommand(final String header) {
+		super("3E00", "3E", "Module discovery probe: " + header);
+		this.header = header;
+	}
 }

--- a/src/main/java/org/obd/metrics/executor/ObdCommandHandler.java
+++ b/src/main/java/org/obd/metrics/executor/ObdCommandHandler.java
@@ -24,6 +24,7 @@ import org.obd.metrics.api.model.Reply;
 import org.obd.metrics.buffer.decoder.ConnectorResponseBuffer;
 import org.obd.metrics.buffer.decoder.ConnectorResponseWrapper;
 import org.obd.metrics.command.Command;
+import org.obd.metrics.command.discovery.ModuleDiscoveryCommand;
 import org.obd.metrics.command.obd.BatchObdCommand;
 import org.obd.metrics.command.obd.ObdCommand;
 import org.obd.metrics.command.routine.RoutineCommand;
@@ -53,8 +54,8 @@ final class ObdCommandHandler implements CommandHandler {
 	public CommandExecutionStatus execute(Connector connector, Command command) {
 		connector.transmit(command);
 		final ConnectorResponse connectorResponse = connector.receive();
-		if (command instanceof RoutineCommand) {
-			log.debug("Received routine commmand response");
+		if (command instanceof RoutineCommand || command instanceof ModuleDiscoveryCommand) {
+			log.debug("Received routine/discovery commmand response");
 			publishResponse(command, connectorResponse);
 		} else {
 			if (connectorResponse.isEmpty()) {

--- a/src/test/java/org/obd/metrics/api/ModuleDiscoveryTest.java
+++ b/src/test/java/org/obd/metrics/api/ModuleDiscoveryTest.java
@@ -1,0 +1,146 @@
+ /**
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.metrics.api;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.obd.metrics.api.model.AdaptiveTimeoutPolicy;
+import org.obd.metrics.api.model.Adjustments;
+import org.obd.metrics.api.model.BatchPolicy;
+import org.obd.metrics.api.model.CachePolicy;
+import org.obd.metrics.api.model.Init;
+import org.obd.metrics.api.model.Init.Header;
+import org.obd.metrics.api.model.Init.Protocol;
+import org.obd.metrics.api.model.Lifecycle;
+import org.obd.metrics.api.model.ModuleDiscoveryStatus;
+import org.obd.metrics.api.model.Pids;
+import org.obd.metrics.api.model.ProducerPolicy;
+import org.obd.metrics.api.model.Query;
+import org.obd.metrics.api.model.Reply;
+import org.obd.metrics.api.model.ReplyObserver;
+import org.obd.metrics.codec.formula.FormulaEvaluatorConfig;
+import org.obd.metrics.command.group.DefaultCommandGroup;
+import org.obd.metrics.pid.Urls;
+import org.obd.metrics.test.DataCollector;
+import org.obd.metrics.test.MockAdapterConnection;
+import org.obd.metrics.test.SimpleLifecycle;
+import org.obd.metrics.test.WorkflowFinalizer;
+import org.obd.metrics.test.WorkflowMonitor;
+import org.obd.metrics.translation.TranslationProvider;
+
+import lombok.NonNull;
+
+public class ModuleDiscoveryTest {
+
+	@SuppressWarnings("unchecked")
+	private static <T extends ReplyObserver<?>> Workflow getWorkflow(Lifecycle lifecycle, T dataCollector) {
+		return Workflow.instance()
+				.translationProvider(TranslationProvider.instance("en"))
+				.formulaEvaluatorConfig(FormulaEvaluatorConfig.builder().scriptEngine("JavaScript").build())
+				.lifecycle(lifecycle)
+				.pids(Pids.builder().resource(Urls.resourceToUrl("giulia_2.0_gme.json")).build())
+				.observer((@NonNull ReplyObserver<Reply<?>>) dataCollector)
+				.initialize();
+	}
+
+	@Test
+	public void discoverModuleReportsFoundWhenModuleAnswers() throws IOException, InterruptedException {
+		SimpleLifecycle lifecycle = new SimpleLifecycle();
+		DataCollector collector = new DataCollector();
+		Workflow workflow = getWorkflow(lifecycle, collector);
+
+		Query query = Query.builder().pid(6L).build();
+
+		MockAdapterConnection connection = MockAdapterConnection.builder()
+				.requestResponse("3E00", "7E00")
+				.build();
+
+		workflow.start(connection, query, createDefaultInit(), createAdjustments());
+		WorkflowMonitor.waitUntilRunning(workflow);
+		Assertions.assertThat(workflow.isRunning()).isTrue();
+
+		WorkflowExecutionStatus status = workflow.discoverModule("DA10F1");
+		Assertions.assertThat(status).isEqualTo(WorkflowExecutionStatus.DISCOVERY_QUEUED);
+
+		WorkflowFinalizer.finalizeAfter(workflow, 800);
+
+		Assertions.assertThat(collector.findATResetCommand()).isNotNull();
+		Assertions.assertThat(lifecycle.getDiscoveredModuleHeader()).isEqualTo("DA10F1");
+		Assertions.assertThat(lifecycle.getModuleDiscoveryStatus()).isEqualTo(ModuleDiscoveryStatus.FOUND);
+
+		Assertions.assertThat(connection.recordedQueries().toString())
+				.contains("ATSHDA10F1")
+				.contains("3E00");
+	}
+
+	@Test
+	public void discoverModuleReportsNotFoundWhenNoModuleAnswers() throws IOException, InterruptedException {
+		SimpleLifecycle lifecycle = new SimpleLifecycle();
+		DataCollector collector = new DataCollector();
+		Workflow workflow = getWorkflow(lifecycle, collector);
+
+		Query query = Query.builder().pid(6L).build();
+
+		MockAdapterConnection connection = MockAdapterConnection.builder()
+				.requestResponse("3E00", "NODATA")
+				.build();
+
+		workflow.start(connection, query, createDefaultInit(), createAdjustments());
+		WorkflowMonitor.waitUntilRunning(workflow);
+		Assertions.assertThat(workflow.isRunning()).isTrue();
+
+		workflow.discoverModule("DAFFF1");
+
+		WorkflowFinalizer.finalizeAfter(workflow, 800);
+
+		Assertions.assertThat(collector.findATResetCommand()).isNotNull();
+		Assertions.assertThat(lifecycle.getDiscoveredModuleHeader()).isEqualTo("DAFFF1");
+		Assertions.assertThat(lifecycle.getModuleDiscoveryStatus()).isEqualTo(ModuleDiscoveryStatus.NOT_FOUND);
+	}
+
+	private Init createDefaultInit() {
+		return Init.builder()
+				.delayAfterInit(0)
+				.header(Header.builder().mode("22").header("DA10F1").build())
+				.header(Header.builder().mode("01").header("DB33F1").build())
+				.protocol(Protocol.CAN_29)
+				.sequence(DefaultCommandGroup.INIT)
+				.build();
+	}
+
+	private Adjustments createAdjustments() {
+		return Adjustments.builder()
+				.debugEnabled(false)
+				.vehicleDtcReadingEnabled(false)
+				.vehicleMetadataReadingEnabled(false)
+				.vehicleCapabilitiesReadingEnabled(false)
+				.cachePolicy(CachePolicy.builder()
+						.storeResultCacheOnDisk(false)
+						.resultCacheEnabled(false).build())
+				.adaptiveTimeoutPolicy(AdaptiveTimeoutPolicy.builder()
+						.enabled(false)
+						.commandFrequency(6)
+						.build())
+				.producerPolicy(ProducerPolicy.builder()
+						.priorityQueueEnabled(true)
+						.build())
+				.batchPolicy(BatchPolicy.builder().enabled(true).build())
+				.build();
+	}
+}


### PR DESCRIPTION
Adds Workflow.discoverModule(header) so a caller can probe a single CAN header for a live module without needing it pre-registered in the PID registry (unlike routines, which require a PidDefinition). Mirrors the existing Routines plumbing: a dedicated ModuleDiscoveryCommand/observer pair reports FOUND/NOT_FOUND/ERROR via a new Lifecycle.onModuleDiscovered callback.

Also fixes a real gap found along the way: ObdCommandHandler only special-cased RoutineCommand to publish a reply even when the adapter returns an empty/NO_DATA response - every other command type silently swallowed empty responses instead of notifying observers. Extended that special-case to ModuleDiscoveryCommand, otherwise a "module not found" probe would never report back at all.